### PR TITLE
handling allowances for ASE 12.5

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -83,6 +83,7 @@ func deleteConnection(conn *Conn) {
 }
 
 const SYBASE string = "sybase"
+const SYBASE_12_5 string = "sybase_12_5"
 
 //Connection to the database.
 type Conn struct {
@@ -221,7 +222,7 @@ func (conn *Conn) getDbProc() (*C.DBPROCESS, error) {
 	// Added for Sybase compatibility mode
 	// Version cannot be set to 7.2
 	// Allowing version to be set inside freetds
-	if conn.credentials.compatibility != SYBASE {
+	if conn.credentials.compatibility != SYBASE && conn.credentials.compatibility != SYBASE_12_5{
 		C.my_setlversion(login)
 	}
 
@@ -428,7 +429,7 @@ func (conn *Conn) setDefaults() error {
 	// Adding check for Sybase compatiblity mode
 	// These connection settings below do not
 	// function with Sybase ASE
-	if conn.credentials.compatibility != SYBASE {
+	if conn.credentials.compatibility != SYBASE && conn.credentials.compatibility != SYBASE_12_5 {
 		//defaults copied from .Net Driver
 		_, err = conn.exec(`
         set quoted_identifier on

--- a/conn_sp.go
+++ b/conn_sp.go
@@ -210,7 +210,7 @@ const sybaseAseGetSpParamsSql string = `
 `
 
 func (conn *Conn) getSpParamsSql(spName string) string {
-	if conn.credentials.compatibility == SYBASE {
+	if conn.credentials.compatibility == SYBASE || conn.credentials.compatibility == SYBASE_12_5 {
 		return fmt.Sprintf(sybaseAseGetSpParamsSql, spName)
 	}
 	return fmt.Sprintf(msSqlGetSpParamsSql, spName)


### PR DESCRIPTION
Handling allowances for ASE 12.5 when functioning as a driver via sql/sqlx

Using dsn argument `Compatibility Mode=Sybase_12_5` instead of `Compatibility Mode=Sybase`

This is needed for Pre-v15 Sybase ASE because `sp_executesql` does not exist in the older versions (12.5 being my target server)